### PR TITLE
Allow data-bouncer-target to contain the message

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ var validate = new Bouncer('form', {
 });
 ```
 
-You can also assign a custom location for an error message by including the `[data-bouncer-target]` attribute on a field. Use a selector for where the message should go as its value.
+You can also assign a custom location for an error message by including the `[data-bouncer-target]` attribute on a field. Use a selector for where the message should go as its value. The error message is inserted before this target. You can optionally render error messages *inside* the target element by setting the `messageInsideTarget` option to `true`.
 
 ```html
 <label for="email">Your Email Address</label>

--- a/src/js/bouncer/bouncer.js
+++ b/src/js/bouncer/bouncer.js
@@ -41,6 +41,7 @@
 
 		// Messages
 		messageAfterField: true,
+		messageInsideTarget: false,
 		messageCustom: 'data-bouncer-message',
 		messageTarget: 'data-bouncer-target',
 		messages: {
@@ -429,6 +430,7 @@
 	/**
 	 * Get the location for a field's error message
 	 * @param  {Node} field      The field
+	 * @param  {Node} target     The target for error message
 	 * @param  {Object} settings The plugin settings
 	 * @return {Node}            The error location
 	 */
@@ -439,6 +441,9 @@
 		if (selector) {
 			var location = field.form.querySelector(selector);
 			if (location) {
+				if (settings.messageInsideTarget) {
+					location = location.appendChild(document.createTextNode(''));
+				}
 				return location;
 			}
 		}


### PR DESCRIPTION
When first using data-bouncer-target I expected the message to be inserted IN the target element. Instead it is inserted BEFORE the target. I created an option to change this behavior. Since data-target-bouncer is a relatively new feature, IMO you should consider making this the default or only behavior.