### PR TITLE
Allow field-specific custom messages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,12 +174,23 @@ Show custom errors for pattern mismatches by adding the `[data-bouncer-message]`
 
 ### Custom Error Messages
 
-Show field-specific custom messages for any validation errors by adding the `[data-bouncer-message]` attribute to the field and setting it to a JSON object with keys matching the `messages` setting.
+Show field-specific custom messages for any validation errors by adding the `[data-bouncer-message-*]` attributes to the input.
+
+* `data-bouncer-message-missing-value`
+* `data-bouncer-message-out-of-range` (used for both over and under)
+* `data-bouncer-message-out-of-range-over`
+* `data-bouncer-message-out-of-range-under`
+* `data-bouncer-message-wrong-length` (used for both over and under)
+* `data-bouncer-message-wrong-length-over`
+* `data-bouncer-message-wrong-length-under`
+* `data-bouncer-message-pattern-mismatch` (or `data-bouncer-message` for compatibility)
 
 ```html
 <!-- Age must be between 13 and 65 yrs. -->
 <input type="number" name="age" min="13" max="65" required
-  data-bouncer-message='{"missingValue": "You must provide your age", "outOfRange":{"over": "You are too old.", "under": "You are too young."}}'>
+	data-bouncer-message-missing-value="You must provide your age"
+	data-bouncer-message-out-of-range-over="You are too old."
+	data-bouncer-message-out-of-range-under="You are too young.">
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -165,13 +165,22 @@ You can use your own validation pattern for a field with the `pattern` attribute
 
 ### Custom Pattern Mismatch Error Messages
 
-Show custom errors for pattern mismatches by adding the `[data-bouncer-message]` attribute to the field.
+Show custom errors for pattern mismatches by adding the `[data-bouncer-message]` attribute to the field and setting it to a string value.
 
 ```html
 <!-- Phone number be in 555-555-5555 format -->
 <input type="text" name="tel" pattern="\d{3}[\-]\d{3}[\-]\d{4}" data-bouncer-message="Please use the following format: 555-555-5555">
 ```
 
+### Custom Error Messages
+
+Show field-specific custom messages for any validation errors by adding the `[data-bouncer-message]` attribute to the field and setting it to a JSON object with keys matching the `messages` setting.
+
+```html
+<!-- Age must be between 13 and 65 yrs. -->
+<input type="number" name="age" min="13" max="65" required
+  data-bouncer-message='{"missingValue": "You must provide your age", "outOfRange":{"over": "You are too old.", "under": "You are too young."}}'>
+```
 
 
 ## Styling Errors

--- a/src/copy/index.html
+++ b/src/copy/index.html
@@ -238,6 +238,12 @@
 						</label>
 					</div>
 
+					<div>
+						<label for="age">Age with min max and custom message <span class="pattern">Must be between 13 and 65</span></label>
+						<input type="number" min="13" max="65" name="age" id="age" required
+						   data-bouncer-message='{"missingValue": "You must provide your age", "outOfRange":{"over": "You are too old.", "under": "You are too young."}}'>
+					</div>
+
 					<input type="submit" class="button" value="Submit">
 				</form>
 			</section>

--- a/src/js/bouncer/bouncer.js
+++ b/src/js/bouncer/bouncer.js
@@ -488,30 +488,22 @@
 	 * @return {String|Function}          The error message
 	 */
 	var getErrorMessage = function (field, errors, settings) {
-		
+
 		// Variables
 		var messages = settings.messages;
-		var customMessages = field.getAttribute(settings.messageCustom);
-		if (customMessages && customMessages.trim().startsWith('{')) {
-			try {
-				customMessages = JSON.parse(customMessages);
-			} catch(e) {
-				customMessages = {};
-			}
-		} else {
-			customMessages = {
-				patternMismatch: customMessages
-			};
-		}
 
 		// Missing value error
 		if (errors.missingValue) {
-			return customMessages.missingValue || messages.missingValue[field.type] || messages.missingValue.default;
+			return field.getAttribute(settings.messageCustom + '-missing-value')
+				|| messages.missingValue[field.type]
+				|| messages.missingValue.default;
 		}
 
 		// Numbers that are out of range
 		if (errors.outOfRange) {
-			var msg = customMessages.outOfRange || messages.outOfRange;
+			var msg = field.getAttribute(settings.messageCustom + '-out-of-range-' + errors.outOfRange)
+				|| field.getAttribute(settings.messageCustom + '-out-of-range')
+				|| messages.outOfRange;
 			if (typeof msg !== 'string') {
 				msg = msg[errors.outOfRange] || messages.fallback;
 			}
@@ -520,7 +512,9 @@
 
 		// Values that are too long or short
 		if (errors.wrongLength) {
-			var msg = customMessages.wrongLength || messages.wrongLength;
+			var msg = field.getAttribute(settings.messageCustom + '-wrong-length-' + errors.wrongLength)
+				|| field.getAttribute(settings.messageCustom + '-wrong-length')
+				|| messages.wrongLength;
 			if (typeof msg !== 'string') {
 				msg = msg[errors.wrongLength] || messages.fallback;
 			}
@@ -529,7 +523,10 @@
 
 		// Pattern mismatch error
 		if (errors.patternMismatch) {
-			return customMessages.patternMismatch || messages.patternMismatch[field.type] || messages.patternMismatch.default;
+			return field.getAttribute(settings.messageCustom + '-pattern-mismatch')
+				|| field.getAttribute(settings.messageCustom)
+				|| messages.patternMismatch[field.type]
+				|| messages.patternMismatch.default;
 		}
 
 		// Custom validations


### PR DESCRIPTION
Override message with specific text for a particular field. For example instead of "Please lengthen this text to 50 characters or more. ..." you might want "You'll never get  the job with a resume less than 50 characters long."

Works for **all** validation errors. The current behavior of `data-bouncer-message` is preserved - it only effects `patternMismatch` errors. You can specify custom messages through attributes like `data-bouncer-message-wrong-length-under` to provide your own validation message for a specific field.

Also made it so you can set `outOfRange` or `wrongLength` to a single string if you want the same message for both edge cases. This works in both `settings.messages` and `data-bouncer-message-out-of-range` or `data-bouncer-message-wrong-length`.