### PR TITLE
Fix removeError

### DIFF
--- a/src/js/bouncer/bouncer.js
+++ b/src/js/bouncer/bouncer.js
@@ -623,12 +623,12 @@
 	 */
 	var removeError = function (field, settings) {
 
-		// Get the error message for this field
+		// Find and remove the error message for this field
 		var error = field.form.querySelector('#' + escapeCharacters(settings.errorPrefix + getFieldID(field, settings)));
-		if (!error) return;
+		if (error) {
+			error.parentNode.removeChild(error);
+		}
 
-		// Remove the error
-		error.parentNode.removeChild(error);
 
 		// Remove error and a11y from the field
 		removeErrorAttributes(field, settings);


### PR DESCRIPTION
If the error message is not there, don't abort clearing the other error attributes.
When specifying custom-message-target it is possible that error message div might not be there.