### PR TITLE
Only run custom validations on fields that need them.

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,9 +218,16 @@ You can see this feature in action with the *Confirm Password* field on [the dem
 
 ### Adding custom validations
 
+Assign an attribute fields that require custom validation. `data-bouncer-custom-validations` contains a space separated list of validator names.
+
 Pass in a `customValidations` object as an option when instantiating a new Bouncer instance. Each property in the object is a new validation type. Each value should be a function that accepts two arguments: the field being validated and the settings for the current instantiation.
 
 The function should *check if the field has an error*. Return `true` if there's an error, and `false` when there's not.
+
+```html
+<label>Must enter hello</label>
+<input type="text" data-bouncer-custom-validations="isHello">
+```
 
 ```js
 var validate = new Bouncer('form', {

--- a/README.md
+++ b/README.md
@@ -226,13 +226,13 @@ The function should *check if the field has an error*. Return `true` if there's 
 
 ```html
 <label>Must enter hello</label>
-<input type="text" data-bouncer-custom-validations="isHello">
+<input type="text" data-bouncer-custom-validations="hello">
 ```
 
 ```js
 var validate = new Bouncer('form', {
 	customValidations: {
-		isHello: function (field) {
+		hello: function (field) {
 
 			// Return false because there is NO error
 			if (field.value === 'hello') return false;
@@ -254,7 +254,7 @@ The key should be the same as your custom validation. It's value can be a string
 ```js
 var validate = new Bouncer('form', {
 	customValidations: {
-		isHello: function (field) {
+		hello: function (field) {
 
 			// Return false because there is NO error
 			if (field.value === 'hello') return false;
@@ -266,10 +266,10 @@ var validate = new Bouncer('form', {
 	},
 	messages: {
 		// As a string
-		isHello: 'This field should have a value of "hello"',
+		hello: 'This field should have a value of "hello"',
 
 		// As a function
-		isHello: function () {
+		hello: function () {
 			return 'This field should have a value of "hello"';
 		}
 	}

--- a/src/copy/index.html
+++ b/src/copy/index.html
@@ -187,12 +187,17 @@
 
 					<div>
 						<label for="confirm-password">Confirm Password <span class="pattern">must match the field above</span></label>
-						<input type="password" name="confirm-password" id="confirm-password" data-bouncer-match="#password" data-bouncer-mismatch-message="Your passwords do not match." required>
+						<input type="password" name="confirm-password" id="confirm-password" data-bouncer-custom-validations="valueMismatch" data-custom-match="#password" data-custom-mismatch-message="Your passwords do not match." required>
 					</div>
 
 					<div>
 						<label for="textminmax">Text with MinLength and MaxLength <span class="pattern">must be between 3 and 9 characters long</span></label>
 						<input type="text" minlength="3" maxlength="9" name="textminmax" id="textminmax" required>
+					</div>
+
+					<div>
+						<label for="palindrome">Enter a palindrome <span class="pattern">must read same forward and backward</span></label>
+						<input type="text" name="palindrome" id="palindrome" data-bouncer-custom-validations="notPalindrome" required>
 					</div>
 
 					<div>
@@ -260,7 +265,7 @@
 
 						// Look for a selector for a field to compare
 						// If there isn't one, return false (no error)
-						var selector = field.getAttribute('data-bouncer-match');
+						var selector = field.getAttribute('data-custom-match');
 						if (!selector) return false;
 
 						// Get the field to compare
@@ -272,13 +277,19 @@
 						// We want to return true for failures, which can be confusing
 						return otherField.value !== field.value;
 
+					},
+					notPalindrome: function (field) {
+						var lowRegStr = field.value.toLowerCase().replace(/[\W_]/g, '');
+						var reverseStr = lowRegStr.split('').reverse().join('');
+						return reverseStr !== lowRegStr;
 					}
 				},
 				messages: {
 					valueMismatch: function (field) {
-						var customMessage = field.getAttribute('data-bouncer-mismatch-message');
+						var customMessage = field.getAttribute('data-custom-mismatch-message');
 						return customMessage ? customMessage : 'Please make sure the fields match.'
-					}
+					},
+					notPalindrome: 'Yo, banana boy! Please enter a palindrome.'
 				}
 			});
 

--- a/src/js/bouncer/bouncer.js
+++ b/src/js/bouncer/bouncer.js
@@ -259,7 +259,9 @@
 	};
 
 	/**
-	 * Run any provided custom validations
+	 * Run any provided custom validations. Custom Validations
+	 * are assigned to field through a space separated list on
+	 * the `data-bouncer-validate` attribute.
 	 * @param  {Node}   field       The field to test
 	 * @param  {Object} errors      The existing errors
 	 * @param  {Object} validations The custom validations to run
@@ -267,10 +269,13 @@
 	 * @return {Object}             The tests and their results
 	 */
 	var customValidations = function (field, errors, validations, settings) {
-		for (var test in validations) {
-			if (validations.hasOwnProperty(test)) {
-				errors[test] = validations[test](field, settings);
-			}
+		var tests = field.getAttribute('data-bouncer-custom-validations');
+		if (tests) {
+			tests.split(' ').forEach(function (test) {
+				if (validations.hasOwnProperty(test)) {
+					errors[test] = validations[test](field, settings);
+				}
+			});
 		}
 		return errors;
 	};


### PR DESCRIPTION
Rather than run every custom validators on every field, assign a list of custom validators to a field, and only run those. This seems cleaner for the general case of custom validators.
For example if you have a form with 15 inputs, and one of them needs the "isHello" validation, rather than run the validation against every field and have to check each field for a marker attribute, you would add `data-bouncer-custom-validations="hello"` to the field that needs it. 
You can specify multiple custom validations in a space-separated list.
In the example for password matching I changed the custom attributes from data-bouncer-* to data-custom-* to avoid confusion that matching is a built-in feature of bouncer. 