### PR TITLE
Error message insertion error

### DIFF
--- a/src/js/bouncer/bouncer.js
+++ b/src/js/bouncer/bouncer.js
@@ -448,7 +448,7 @@
 
 		// If the message should come after the field
 		if (settings.messageAfterField) {
-			return target.nextSibling;
+			return target.nextSibling || target.parentElement.appendChild(document.createTextNode(''));
 		}
 
 		// If it should come before


### PR DESCRIPTION
When adding the error message nextSibling could be null (if the input is wrapped in a div). If that happens createError can get a null for location and it blows up.