### PR TITLE
Add disableValidateOnXxx settings

### DIFF
--- a/src/js/bouncer/bouncer.js
+++ b/src/js/bouncer/bouncer.js
@@ -75,6 +75,12 @@
 		// Form Submission
 		disableSubmit: false,
 
+		// Validation enable/disable
+		disableValidateOnBlur: false,
+		disableValidateOnInput: false,
+		disableValidateOnClick: false,
+		disableValidateOnSubmit: false,
+
 		// Custom Events
 		emitEvents: true
 
@@ -789,10 +795,10 @@
 		publicAPIs.destroy = function () {
 
 			// Remove event listeners
-			document.removeEventListener('blur', blurHandler, true);
-			document.removeEventListener('input', inputHandler, false);
-			document.removeEventListener('click', inputHandler, false);
-			document.removeEventListener('submit', submitHandler, false);
+			if (! settings.disableValidateOnBlur) document.removeEventListener('blur', blurHandler, true);
+			if (! settings.disableValidateOnInput) document.removeEventListener('input', inputHandler, false);
+			if (! settings.disableValidateOnClick) document.removeEventListener('click', inputHandler, false);
+			if (! settings.disableValidateOnSubmit) document.removeEventListener('submit', submitHandler, false);
 
 			// Remove all errors
 			removeAllErrors(selector, settings);
@@ -824,10 +830,10 @@
 			addNoValidate(selector);
 
 			// Event Listeners
-			document.addEventListener('blur', blurHandler, true);
-			document.addEventListener('input', inputHandler, false);
-			document.addEventListener('click', inputHandler, false);
-			document.addEventListener('submit', submitHandler, false);
+			if (! settings.disableValidateOnBlur) document.addEventListener('blur', blurHandler, true);
+			if (! settings.disableValidateOnInput) document.addEventListener('input', inputHandler, false);
+			if (! settings.disableValidateOnClick) document.addEventListener('click', inputHandler, false);
+			if (! settings.disableValidateOnSubmit) document.addEventListener('submit', submitHandler, false);
 
 			// Emit custom event
 			if (settings.emitEvents) {


### PR DESCRIPTION
_What_ : New config. settings, for allowing to selectively disable one or more event handlers, on blur, and/or on input, and/or on click, and/or on submit.

_Rationale_ : Allow to solve some use cases : 

- **disableValidateOnInput**
Allow to disable the validation & error refresh on each user keystroke.
Showing & refreshing errors on each user keystroke may be seen as annoying to some users, so the ability to disable it can be useful.  _(this is the use case which I have a use for)_.

- **disableValidateOnBlur**, **disableValidateOnSubmit**
See pull request https://github.com/cferdinandi/bouncer/pull/55 for use cases.

- Another example use case is when willing to have minimal interference towards user, by performing client-side validation only when user submits the form -> this can be configured with the combination of disableValidateOnInput + disableValidateOnBlur + disableValidateOnClick. 
