### PR TITLE
Add disableValidateReadonly setting

### DIFF
--- a/src/js/bouncer/bouncer.js
+++ b/src/js/bouncer/bouncer.js
@@ -512,12 +512,20 @@
 
 		// Numbers that are out of range
 		if (errors.outOfRange) {
-			return messages.outOfRange[errors.outOfRange].replace('{max}', field.getAttribute('max')).replace('{min}', field.getAttribute('min')).replace('{length}', field.value.length);
+			var message = messages.outOfRange[errors.outOfRange];
+			if (message instanceof String) {
+				message = message.replace('{max}', field.getAttribute('max')).replace('{min}', field.getAttribute('min')).replace('{length}', field.value.length);
+			}
+			return message;
 		}
 
 		// Values that are too long or short
 		if (errors.wrongLength) {
-			return messages.wrongLength[errors.wrongLength].replace('{maxLength}', field.getAttribute('maxlength')).replace('{minLength}', field.getAttribute('minlength')).replace('{length}', field.value.length);
+			var message = messages.wrongLength[errors.wrongLength];
+			if (message instanceof String) {
+				message = message.replace('{maxLength}', field.getAttribute('maxlength')).replace('{minLength}', field.getAttribute('minlength')).replace('{length}', field.value.length);
+			}
+			return message;
 		}
 
 		// Pattern mismatch error

--- a/src/js/bouncer/bouncer.js
+++ b/src/js/bouncer/bouncer.js
@@ -75,6 +75,12 @@
 		// Form Submission
 		disableSubmit: false,
 
+		// Validation enable/disable
+		disableValidateOnBlur: false,
+		disableValidateOnInput: false,
+		disableValidateOnClick: false,
+		disableValidateOnSubmit: false,
+
 		// Custom Events
 		emitEvents: true
 
@@ -789,10 +795,10 @@
 		publicAPIs.destroy = function () {
 
 			// Remove event listeners
-			document.removeEventListener('blur', blurHandler, true);
-			document.removeEventListener('input', inputHandler, false);
-			document.removeEventListener('click', inputHandler, false);
-			document.removeEventListener('submit', submitHandler, false);
+			if (! settings.disableValidateOnBlur) document.removeEventListener('blur', blurHandler, true);
+			if (! settings.disableValidateOnInput) document.removeEventListener('input', inputHandler, false);
+			if (! settings.disableValidateOnClick) document.removeEventListener('click', inputHandler, false);
+			if (! settings.disableValidateOnSubmit) document.removeEventListener('submit', submitHandler, false);
 
 			// Remove all errors
 			removeAllErrors(selector, settings);
@@ -824,10 +830,10 @@
 			addNoValidate(selector);
 
 			// Event Listeners
-			document.addEventListener('blur', blurHandler, true);
-			document.addEventListener('input', inputHandler, false);
-			document.addEventListener('click', inputHandler, false);
-			document.addEventListener('submit', submitHandler, false);
+			if (! settings.disableValidateOnBlur) document.addEventListener('blur', blurHandler, true);
+			if (! settings.disableValidateOnInput) document.addEventListener('input', inputHandler, false);
+			if (! settings.disableValidateOnClick) document.addEventListener('click', inputHandler, false);
+			if (! settings.disableValidateOnSubmit) document.addEventListener('submit', submitHandler, false);
 
 			// Emit custom event
 			if (settings.emitEvents) {

--- a/src/js/bouncer/bouncer.js
+++ b/src/js/bouncer/bouncer.js
@@ -80,6 +80,7 @@
 		disableValidateOnInput: false,
 		disableValidateOnClick: false,
 		disableValidateOnSubmit: false,
+		disableValidateReadonly: true,
 
 		// Custom Events
 		emitEvents: true
@@ -701,11 +702,11 @@
 		 */
 		publicAPIs.validate = function (field, options) {
 
-			// Don't validate submits, buttons, file and reset inputs, and disabled and readonly fields
-			if (field.disabled || field.readOnly || field.type === 'reset' || field.type === 'submit' || field.type === 'button') return;
-
 			// Local settings
 			var _settings = extend(settings, options || {});
+
+			// Don't validate submits, buttons, file and reset inputs, and disabled and readonly fields
+			if (field.disabled || (field.readOnly && _settings.disableValidateReadonly) || field.type === 'reset' || field.type === 'submit' || field.type === 'button') return;
 
 			// Check for errors
 			var isValid = getErrors(field, _settings);


### PR DESCRIPTION
Allow to perform validation when field is readonly.

Use case : 
When some javascript component actually populates the input field content (not directly the user), for example a javascript date picker.
The field value is GUI-selected by the user via the javascript widget.
The field is readonly, to prevent user from directly inputting textual value in wrong format.
Yet, it is expected that bouncer.js performs validation of the input (and refresh of the error message), on the "required" html constraint ( = the field must have a value).

How : 
I propose to add a setting : disableValidateReadonly 
when set to true (default), the behavior is unchanged : bouncer.js does not perform validation when a field is readonly.
when set to false, bouncer.js performs validation when a field is readonly.
